### PR TITLE
➕ Add font weights as strings to enum

### DIFF
--- a/packages/support/src/Enums/FontWeight.php
+++ b/packages/support/src/Enums/FontWeight.php
@@ -2,21 +2,21 @@
 
 namespace Filament\Support\Enums;
 
-enum FontWeight
+enum FontWeight: string
 {
-    case Thin;
+    case Thin = 'thin';
 
-    case ExtraLight;
+    case ExtraLight = 'extralight';
 
-    case Light;
+    case Light = 'light';
 
-    case Medium;
+    case Medium = 'medium';
 
-    case SemiBold;
+    case SemiBold = 'semibold';
 
-    case Bold;
+    case Bold = 'bold';
 
-    case ExtraBold;
+    case ExtraBold = 'extrabold';
 
-    case Black;
+    case Black = 'black';
 }


### PR DESCRIPTION
## Description

Add font weights as strings to `FontWeight` enum to be used as classes in templates.

## Code style

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.
